### PR TITLE
Add support for decoding JWT tokens

### DIFF
--- a/django_keycloak/backends.py
+++ b/django_keycloak/backends.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.backends import RemoteUserBackend
 from django.contrib.auth import get_user_model
 from django_keycloak.keycloak import Connect
+from django_keycloak.models import KeycloakUserAutoId
 
 
 class KeycloakAuthenticationBackend(RemoteUserBackend):
@@ -8,40 +9,37 @@ class KeycloakAuthenticationBackend(RemoteUserBackend):
     def authenticate(self, request, username=None, password=None):
         keycloak = Connect()
         token = keycloak.get_token_from_credentials(username, password).get("access_token")
-        user = get_user_model()
+        User = get_user_model()
         if not keycloak.is_token_active(token):
             return
         try:
-            user = user.objects.get(username=username)
-            # Get user info based on token
-            user_info = keycloak.get_user_info(token)
+            user = User.objects.get(username=username)
+            if isinstance(user, KeycloakUserAutoId):
+                # Get user info based on token
+                user_info = keycloak.get_user_info(token)
 
-            # Get user info and update
-            user.first_name = user_info.get('given_name')
-            user.last_name = user_info.get('family_name')
-            user.email = user_info.get('email')
-            user.save()
-
-        except user.DoesNotExist:
-            user = user.objects.create_user(username, password)
-
+                # Get user info and update
+                user.first_name = user_info.get('given_name')
+                user.last_name = user_info.get('family_name')
+                user.email = user_info.get('email')
+        except User.DoesNotExist:
+            user = User.objects.create_user(username, password)
         if keycloak.has_superuser_perm(token):
             user.is_staff = True
             user.is_superuser = True
-            user.save()
         else:
             user.is_staff = False
             user.is_superuser = False
-            user.save()
+        user.save()
 
         return user
 
     def get_user(self, user_identifier):
-        user = get_user_model()
+        User = get_user_model()
         try:
-            return user.objects.get(username=user_identifier)
-        except user.DoesNotExist:
+            return User.objects.get(username=user_identifier)
+        except User.DoesNotExist:
             try:
-                return user.objects.get(id=user_identifier)
-            except user.DoesNotExist:
+                return User.objects.get(id=user_identifier)
+            except User.DoesNotExist:
                 return None

--- a/django_keycloak/keycloak.py
+++ b/django_keycloak/keycloak.py
@@ -394,7 +394,7 @@ class Connect:
         headers = {}
         if self.internal_url:
             server_url = self.internal_url
-            headers["HOST"] = urlparse(self.server_url).netloc
+            headers["HOST"] = urlparse(self.internal_url).netloc
         return [server_url, headers]
 
     def _decode_token(

--- a/django_keycloak/keycloak.py
+++ b/django_keycloak/keycloak.py
@@ -102,9 +102,8 @@ class Connect:
         @param token: request token
         @return: introspected token
         """
-        if hasattr(self, "cached_introspect"):
-            if self.cached_token == token:
-                return self.cached_introspect
+        if self.cached_introspect and self.cached_token == token:
+            return self.cached_introspect
 
         payload = {
             "token": token,

--- a/django_keycloak/keycloak.py
+++ b/django_keycloak/keycloak.py
@@ -1,15 +1,24 @@
+from datetime import datetime, timezone
+from functools import cached_property
+from typing import Dict, List, Optional, Union
 from urllib.parse import urlparse
 
+import jwt
 import requests
 from django.conf import settings
+from jwt import PyJWKClient
+from jwt.exceptions import InvalidTokenError
 
 from .decorators import keycloak_api_error_handler
 from .urls import (
+    KEYCLOAK_CREATE_USER,
+    KEYCLOAK_DELETE_USER,
     KEYCLOAK_GET_TOKEN,
     KEYCLOAK_GET_USER_BY_ID,
     KEYCLOAK_GET_USERS,
     KEYCLOAK_INTROSPECT_TOKEN,
     KEYCLOAK_USER_INFO,
+    KEYCLOAK_OPENID_CONFIG,
     KEYCLOAK_UPDATE_USER,
     KEYCLOAK_CREATE_USER,
     KEYCLOAK_GET_USER_CLIENT_ROLES_BY_ID,
@@ -48,9 +57,23 @@ class Connect:
             self.realm_admin_role = self.config.get("REALM_ADMIN_ROLE", "admin")
             self.graphql_endpoint = self.config.get("GRAPHQL_ENDPOINT", None)
             self.exempt_uris = self.config.get("EXEMPT_URIS", [])
+            # Flag if the token should be introspected or decoded
+            self.enable_token_decoding = self.config.get("DECODE_TOKEN", False)
+            # The percentage of a tokens valid duration until a new token is requested
+            self.token_timeout_factor = self.config.get("TOKEN_TIMEOUT_FACTOR", 0.9)
+            # A token belonging to a user and the respective introspection
+            self.cached_token = None
+            self.cached_introspect = None
+            # A token belonging to the client to perform user management
+            self._client_token = None
+            # Audiences for the different JWT uses
+            self.client_jwt_audience = self.config.get(
+                "CLIENT_JWT_AUDIENCE", "realm-management"
+            )
+            self.user_jwt_audience = self.config.get("USER_JWT_AUDIENCE", "account")
 
-        except KeyError:
-            raise Exception("KEYCLOAK configuration is not defined.")
+        except KeyError as err:
+            raise Exception("KEYCLOAK configuration is not defined.") from err
 
         if not self.server_url:
             raise Exception("SERVER_URL is not defined.")
@@ -63,6 +86,16 @@ class Connect:
 
         if not self.client_secret_key:
             raise Exception("CLIENT_SECRET_KEY is not defined.")
+
+    @cached_property
+    def openid_config(self):
+        """Collects the identity provider's configuration"""
+        return self._get_openid_config()
+
+    @cached_property
+    def jwks_client(self):
+        """Collects the identity provider's public keys"""
+        return PyJWKClient(self.openid_config["jwks_uri"])
 
     def introspect(self, token):
         """
@@ -79,14 +112,7 @@ class Connect:
             "grant_type": "client_credentials",
             "client_secret": self.client_secret_key,
         }
-        headers = {
-            "Content-Type": "application/x-www-form-urlencoded",
-        }
-
-        server_url = self.server_url
-        if self.internal_url:
-            server_url = self.internal_url
-            headers["HOST"] = urlparse(self.server_url).netloc
+        server_url, headers = self._make_form_request_config()
 
         response = requests.request(
             "POST",
@@ -110,14 +136,7 @@ class Connect:
             "password": password,
             "scope": "openid",
         }
-        headers = {
-            "Content-Type": "application/x-www-form-urlencoded",
-        }
-
-        server_url = self.server_url
-        if self.internal_url:
-            server_url = self.internal_url
-            headers["HOST"] = urlparse(self.server_url).netloc
+        server_url, headers = self._make_form_request_config()
 
         response = requests.request(
             "POST",
@@ -137,14 +156,7 @@ class Connect:
             "client_secret": self.client_secret_key,
             "refresh_token": refresh_token,
         }
-        headers = {
-            "Content-Type": "application/x-www-form-urlencoded",
-        }
-
-        server_url = self.server_url
-        if self.internal_url:
-            server_url = self.internal_url
-            headers["HOST"] = urlparse(self.server_url).netloc
+        server_url, headers = self._make_form_request_config()
 
         response = requests.request(
             "POST",
@@ -156,23 +168,19 @@ class Connect:
 
     def get_token(self):
         """
-        Get Token based on client credentials
+        Get a client token based on client credentials
         @return:
         """
+
+        if not self._is_client_token_timed_out():
+            return self._client_token
 
         payload = {
             "grant_type": "client_credentials",
             "client_id": self.client_id,
             "client_secret": self.client_secret_key,
         }
-        headers = {
-            "Content-Type": "application/x-www-form-urlencoded",
-        }
-
-        server_url = self.server_url
-        if self.internal_url:
-            server_url = self.internal_url
-            headers["HOST"] = urlparse(self.server_url).netloc
+        server_url, headers = self._make_form_request_config()
 
         response = requests.request(
             "POST",
@@ -180,22 +188,15 @@ class Connect:
             data=payload,
             headers=headers,
         )
-        return response.json().get("access_token")
+        self._client_token = response.json().get("access_token")
+        return self._client_token
 
     def get_users(self, **params):
         """
         Get users for realm
         @return:
         """
-        token = self.get_token()
-        headers = {
-            "Content-Type": "application/json",
-            "Authorization": "Bearer {}".format(token),
-        }
-        server_url = self.server_url
-        if self.internal_url:
-            server_url = self.internal_url
-            headers["HOST"] = urlparse(self.server_url).netloc
+        server_url, headers = self._make_secure_json_request_config()
 
         response = requests.request(
             "GET",
@@ -209,12 +210,10 @@ class Connect:
         """
         Get user information token
         """
-        headers = {"authorization": "Bearer " + token}
-        server_url = self.server_url
-        if self.internal_url:
-            server_url = self.internal_url
-            headers["HOST"] = urlparse(self.server_url).netloc
+        if self.enable_token_decoding:
+            return self._decode_token(token, self.user_jwt_audience)
 
+        server_url, headers = self._make_secure_request_config(token)
         response = requests.request(
             "GET", KEYCLOAK_USER_INFO.format(server_url, self.realm), headers=headers
         )
@@ -224,13 +223,18 @@ class Connect:
         """
         Verify if introspect token is active.
         """
-        introspect_token = self.introspect(token)
-        return introspect_token.get("sub", None)
+        if self.enable_token_decoding:
+            token_data = self._decode_token(token, self.user_jwt_audience)
+        else:
+            token_data = self.introspect(token)
+        return token_data.get("sub", None)
 
     def is_token_active(self, token):
         """
         Verify if introspect token is active.
         """
+        if self.enable_token_decoding:
+            return bool(self._decode_token(token, audience=self.user_jwt_audience))
         introspect_token = self.introspect(token)
         return introspect_token.get("active", False)
 
@@ -238,14 +242,22 @@ class Connect:
         """
         Get client roles from token
         """
-        client_id = self.introspect(token).get("resource_access").get(self.client_id)
-        return client_id.get("roles", []) if client_id else []
+        if self.enable_token_decoding:
+            token_data = self._decode_token(token, self.user_jwt_audience)
+        else:
+            token_data = self.introspect(token)
+        client_resources = token_data.get("resource_access").get(self.client_id)
+        return client_resources.get("roles", []) if client_resources else []
 
     def realm_roles(self, token):
         """
         Get realm roles from token
         """
-        return self.introspect(token).get("realm_access").get("roles", None)
+        if self.enable_token_decoding:
+            token_data = self._decode_token(token, self.user_jwt_audience)
+        else:
+            token_data = self.introspect(token)
+        return token_data.get("realm_access").get("roles", None)
 
     def client_scope(self, token):
         """
@@ -267,17 +279,7 @@ class Connect:
         """
         Get user info from the id
         """
-
-        token = self.get_token()
-        headers = {
-            "Content-Type": "application/json",
-            "Authorization": "Bearer {}".format(token),
-        }
-
-        server_url = self.server_url
-        if self.internal_url:
-            server_url = self.internal_url
-            headers["HOST"] = urlparse(self.server_url).netloc
+        server_url, headers = self._make_secure_json_request_config()
 
         response = requests.request(
             "GET",
@@ -314,16 +316,7 @@ class Connect:
         """
         Update user with values
         """
-        token = self.get_token()
-        headers = {
-            "Content-Type": "application/json",
-            "Authorization": "Bearer {}".format(token),
-        }
-
-        server_url = self.server_url
-        if self.internal_url:
-            server_url = self.internal_url
-            headers["HOST"] = urlparse(self.server_url).netloc
+        server_url, headers = self._make_secure_json_request_config()
 
         current_user = self.get_user_info_by_id(user_id)
         data = {
@@ -338,17 +331,102 @@ class Connect:
 
     @keycloak_api_error_handler
     def create_user(self, **values):
-        token = self.get_token()
-        headers = {
-            "Content-Type": "application/json",
-            "Authorization": "Bearer {}".format(token),
-        }
-
-        server_url = self.server_url
-        if self.internal_url:
-            server_url = self.internal_url
-            headers["HOST"] = urlparse(self.server_url).netloc
+        server_url, headers = self._make_secure_json_request_config()
 
         url = KEYCLOAK_CREATE_USER.format(server_url, self.realm)
         res = requests.post(url, headers=headers, json=values)
         res.raise_for_status()
+        return res.headers["Location"].split("/")[-1]
+
+    @keycloak_api_error_handler
+    def delete_user(self, user_id):
+        server_url, headers = self._make_secure_json_request_config()
+
+        url = KEYCLOAK_DELETE_USER.format(server_url, self.realm, user_id)
+        res = requests.delete(url, headers=headers)
+        res.raise_for_status()
+
+    def _is_client_token_timed_out(self):
+        """
+        Checks if the cached token is timed out as given by the timeout factor
+
+        If there is no cached token, returns true. Timeout is true if the current time is
+        later than (expiration time - issue time) * timeout factor + issue time.
+        """
+        if not self._client_token:
+            return True
+
+        # Get the public key from the identity provider, i.e., the keycloak server
+        decoded = self._decode_token(self._client_token, self.client_jwt_audience)
+        exp = datetime.fromtimestamp(decoded["exp"], tz=timezone.utc)
+        iat = datetime.fromtimestamp(decoded["iat"], tz=timezone.utc)
+        now = datetime.now(tz=timezone.utc)
+
+        is_timed_out = (exp - iat) * self.token_timeout_factor + iat < now
+        return is_timed_out
+
+    def _get_openid_config(self):
+        server_url, headers = self._make_json_request_config()
+
+        response = requests.request(
+            "GET",
+            KEYCLOAK_OPENID_CONFIG.format(server_url, self.realm),
+            headers=headers,
+        )
+        return response.json()
+
+    def _make_secure_request_config(self, token):
+        server_url, headers = self._make_request_config()
+        if not token:
+            token = self.get_token()
+        headers["Authorization"] = f"Bearer {token}"
+        return [server_url, headers]
+
+    def _make_secure_json_request_config(self, token=None):
+        server_url, headers = self._make_request_config()
+        if not token:
+            token = self.get_token()
+        headers["Content-Type"] = "application/json"
+        headers["Authorization"] = f"Bearer {token}"
+        return [server_url, headers]
+
+    def _make_form_request_config(self):
+        server_url, headers = self._make_request_config()
+        headers["Content-Type"] = "application/x-www-form-urlencoded"
+        return [server_url, headers]
+
+    def _make_json_request_config(self):
+        server_url, headers = self._make_request_config()
+        headers["Content-Type"] = "application/json"
+        return [server_url, headers]
+    
+    def _make_request_config(self):
+        server_url = self.server_url
+        headers = {}
+        if self.internal_url:
+            server_url = self.internal_url
+            headers["HOST"] = urlparse(self.server_url).netloc
+        return [server_url, headers]
+
+    def _decode_token(
+        self, token: str, audience: Union[str, List[str]], raise_error=False
+    ) -> Optional[Dict]:
+        """
+        Attempts to decode the token. Returns a Dict on success or none on failure
+        """
+        try:
+            # Get the public key from the identity provider, i.e., the keycloak server
+            public_key = self.jwks_client.get_signing_key_from_jwt(token).key
+            # Decode and verify the JWT with the server's public key specified in the
+            # JWT's header, the required audience and the allowed crypto algorithms it
+            # published
+            return jwt.decode(
+                token,
+                public_key,
+                audience=audience,
+                algorithms=self.openid_config["id_token_signing_alg_values_supported"],
+            )
+        except InvalidTokenError as err:
+            if raise_error:
+                raise err
+            return None

--- a/django_keycloak/keycloak.py
+++ b/django_keycloak/keycloak.py
@@ -291,17 +291,7 @@ class Connect:
         """
         Get user client roles from the id
         """
-
-        token = self.get_token()
-        headers = {
-            "Content-Type": "application/json",
-            "Authorization": "Bearer {}".format(token),
-        }
-
-        server_url = self.server_url
-        if self.internal_url:
-            server_url = self.internal_url
-            headers["HOST"] = urlparse(self.server_url).netloc
+        server_url, headers = self._make_secure_json_request_config()
 
         response = requests.request(
             "GET",

--- a/django_keycloak/mixins.py
+++ b/django_keycloak/mixins.py
@@ -1,0 +1,27 @@
+from django_keycloak.keycloak import Connect
+
+
+class KeycloakTestMixin:
+    """
+    Cleans up the users created on the Keycloak server as test side-effects.
+
+    Stores all Keycloak users at the start of a test and compares them to those at the
+    end. Removes all new users.
+
+    Usage: Add the mixin before the TestCase class and call super().setUp()/tearDown() if
+    adding your own setUp and tearDown functions.
+
+    class LoginTests(KeycloakTestMixin, TestCase):
+        def setUp(self):
+            super().setUp()
+            ...
+    """
+    def setUp(self): #pylint: disable=invalid-name
+        self.keycloak = Connect()
+        self._start_users = {user.get("id") for user in self.keycloak.get_users()}
+
+    def tearDown(self): #pylint: disable=invalid-name
+        new_users = {user.get("id") for user in self.keycloak.get_users()}
+        users_to_remove = new_users.difference(self._start_users)
+        for user_id in users_to_remove:
+            self.keycloak.delete_user(user_id)

--- a/django_keycloak/models.py
+++ b/django_keycloak/models.py
@@ -32,11 +32,6 @@ class AbstractKeycloakUser(AbstractBaseUser, PermissionsMixin):
     def full_name(self):
         return f"{self.first_name} {self.last_name}"
 
-    def _confirm_cache(self):
-        if not self._cached_user_info:
-            keycloak = Connect()
-            self._cached_user_info = keycloak.get_user_info_by_id(self.id)
-
     class Meta(AbstractBaseUser.Meta):
         abstract = True
 
@@ -76,6 +71,11 @@ class KeycloakUser(AbstractKeycloakUser):
     def last_name(self):
         self._confirm_cache()
         return self._cached_user_info.get("lastName")
+    
+    def _confirm_cache(self):
+        if not self._cached_user_info:
+            keycloak = Connect()
+            self._cached_user_info = keycloak.get_user_info_by_id(self.id)
 
 
 class AbstractKeycloakUserAutoId(AbstractKeycloakUser):
@@ -102,7 +102,7 @@ class AbstractKeycloakUserAutoId(AbstractKeycloakUser):
         return self.keycloak_id
 
     def _confirm_cache(self):
-        if not hasattr(self, "_cached_user_info"):
+        if not self._cached_user_info:
             keycloak = Connect()
             self._cached_user_info = keycloak.get_user_info_by_id(self.keycloak_id)
 

--- a/django_keycloak/urls.py
+++ b/django_keycloak/urls.py
@@ -8,6 +8,8 @@ KEYCLOAK_GET_USER_CLIENT_ROLES_BY_ID = "{}/auth/admin/realms/{}/users/{}/role-ma
 KEYCLOAK_UPDATE_USER = "{}/auth/admin/realms/{}/users/{}"
 KEYCLOAK_CREATE_USER = "{}/auth/admin/realms/{}/users"
 KEYCLOAK_SEND_ACTIONS_EMAIL = "{}/auth/admin/realms/{}/users/{}/execute-actions-email"
+KEYCLOAK_DELETE_USER = "{}/auth/admin/realms/{}/users/{}"
+KEYCLOAK_OPENID_CONFIG = "{}/auth/realms/{}/.well-known/openid-configuration"
 
 
 # ADMIN CONSOLE

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django_uw_keycloak
-version = 0.8.7
+version = 1.0
 description = Middleware to allow authorization using Keycloak and Django
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8; variant=GFM

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,4 +19,8 @@ include_package_data = true
 packages = find:
 install_requires =
     Django >= "2.2"
+    rest_framework ~= "3.0"
+    dry-rest-permissions ~= "0.1"
+    jwt ~= "1.0"
+    requests ~= "2.0"
 


### PR DESCRIPTION
Why:

- Extract microprofile from JWT instead of querying Keycloak
- Retain KeycloakUser model
- Enable Keycloak integration in tests
- Add compatibility with async web servers
- Add support for generating users with passwords
- Fix misc. bugs

This change addresses the need by:

- Add urls to delete users and fetch keys to decode JWTs
- Keep KeycloakUser as first class model
- Add TestMixin to help with cleanup of integration tests
- Mark middleware as sync-only compatible to trigger wrapper
- Fix GraphQL url check
- Fix user not being added to requests
- Add password parameter for creating users