### PR TITLE
Make KeycloakTestMixin explicit

### DIFF
--- a/django_keycloak/mixins.py
+++ b/django_keycloak/mixins.py
@@ -1,3 +1,4 @@
+import logging
 from django_keycloak.keycloak import Connect
 
 
@@ -8,20 +9,34 @@ class KeycloakTestMixin:
     Stores all Keycloak users at the start of a test and compares them to those at the
     end. Removes all new users.
 
-    Usage: Add the mixin before the TestCase class and call super().setUp()/tearDown() if
-    adding your own setUp and tearDown functions.
+    Usage: In the test class, derive from this mixin and call keycloak_init/teardown in
+    the setUp and tearDown functions.
 
     class LoginTests(KeycloakTestMixin, TestCase):
         def setUp(self):
-            super().setUp()
+            keycloak_init()
+            ...
+
+        def tearDown(self):
+            keycloak_teardown()
             ...
     """
 
     def setUp(self):  # pylint: disable=invalid-name
+        logging.warning("Please call keycloak_init() manually", DeprecationWarning, 2)
+        self.keycloak_init()
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        logging.warning(
+            "Please call keycloak_cleanup() manually", DeprecationWarning, 2
+        )
+        self.keycloak_cleanup()
+
+    def keycloak_init(self):
         self.keycloak = Connect()
         self._start_users = {user.get("id") for user in self.keycloak.get_users()}
 
-    def tearDown(self):  # pylint: disable=invalid-name
+    def keycloak_cleanup(self):
         new_users = {user.get("id") for user in self.keycloak.get_users()}
         users_to_remove = new_users.difference(self._start_users)
         for user_id in users_to_remove:


### PR DESCRIPTION
Why:

- Avoid strange errors due to import order

This change addresses the need by:

- Adding keycloak_init/cleanup methods
- Deprecating 'magic' setUp and tearDown methods

Closes #15 