### PR TITLE
Mark unused GraphQL middleware as deprecated

### DIFF
--- a/django_keycloak/middleware.py
+++ b/django_keycloak/middleware.py
@@ -1,3 +1,4 @@
+import logging
 import re
 
 from django.contrib.auth import get_user_model
@@ -67,6 +68,9 @@ class KeycloakGrapheneMiddleware(KeycloakMiddlewareMixin):
     """
 
     def __init__(self):
+        logging.warning(
+            "All functionality is provided by KeycloakMiddleware", DeprecationWarning, 2
+        )
         self.keycloak = Connect()
 
     def resolve(self, next, root, info, **kwargs):


### PR DESCRIPTION
Why:

- Functionality covered by KeycloakMiddleware

This change addresses the need by:

- Adding a deprecation warning to KeycloakGrapheneMiddleware

Closes #5 