### PR TITLE
Speed up JWT decoding

### DIFF
--- a/django_keycloak/keycloak.py
+++ b/django_keycloak/keycloak.py
@@ -8,6 +8,7 @@ import requests
 from django.conf import settings
 from jwt import PyJWKClient
 from jwt.exceptions import InvalidTokenError
+from cachetools.func import ttl_cache
 
 from .decorators import keycloak_api_error_handler
 from .urls import (
@@ -399,6 +400,7 @@ class Connect:
             headers["HOST"] = urlparse(self.internal_url).netloc
         return [server_url, headers]
 
+    @ttl_cache(maxsize=128, ttl=60)
     def _decode_token(
         self, token: str, audience: Union[str, List[str]], raise_error=False
     ) -> Optional[Dict]:

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,4 +23,5 @@ install_requires =
     dry-rest-permissions >= "0.1"
     jwt >= "1.0"
     requests >= "2.0"
+    cachetools >= "5.0"
 


### PR DESCRIPTION
Why:

- Almost 10x speed increase
- Total response 20% less time

This change addresses the need by:

- Adding TTL LRU cache to the decode function

Closes #18 