### PR TITLE
Fix misnamed libraries

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,8 +19,8 @@ include_package_data = true
 packages = find:
 install_requires =
     Django >= "2.2"
-    rest_framework >= "3.0"
+    djangorestframework >= "3.0"
     dry-rest-permissions >= "0.1"
-    jwt >= "1.0"
+    PyJWT >= "2.3"
     requests >= "2.0"
 


### PR DESCRIPTION
Why:

- Avoid package collisions during install

This change addresses the need by:

- Renaming the packages

Closes #20 