### PR TITLE
Make middleware async capable

### DIFF
--- a/django_keycloak/middleware.py
+++ b/django_keycloak/middleware.py
@@ -100,43 +100,32 @@ class KeycloakMiddleware(KeycloakMiddlewareMixin, MiddlewareMixin):
     Middleware to validate Keycloak access based on REST validations
     """
 
-    sync_capable = True
-    async_capable = False
-
     def __init__(self, get_response):
+        super().__init__(get_response)
         self.keycloak = Connect()
 
-        # Django response
-        self.get_response = get_response
-
-    def __call__(self, request):
+    def process_request(self, request):
         """
         To be executed before the view each request
         """
         # Skip auth for gql endpoint (it is done in KeycloakGrapheneMiddleware)
         if self.is_graphql_endpoint(request):
-            return self.get_response(request)
-
-        if not self.is_auth_header_missing(request):
-            token = self.get_token(request)
-            if token is None:
-                return JsonResponse(
-                    {"detail": "Invalid token structure. Must be 'Bearer <token>'"},
-                    status=401,
-                )
-
+            return
+        # Extract token from "Bearer <token>" string
+        if auth_value := request.META.get("HTTP_AUTHORIZATION"):
+            split_auth_value = auth_value.split("Bearer ")
+            if len(split_auth_value) != 2:
+                return
+            token = split_auth_value[1]
             if not self.keycloak.is_token_active(token):
-                return JsonResponse(
-                    {"detail": "Invalid or expired token."},
-                    status=401,
-                )
-            request = self.append_user_info_to_request(request, token)
-        return self.get_response(request)
+                return JsonResponse({"detail": "Invalid or expired token."}, status=401)
+            self.append_user_info_to_request(request, token)
 
     def pass_auth(self, request):
         """
         Check if the current URI path needs to skip authorization
         """
+        logging.warning("Not used by middleware", DeprecationWarning, 2)
         path = request.path_info.lstrip("/")
         return any(re.match(m, path) for m in self.keycloak.exempt_uris)
 


### PR DESCRIPTION
Why:

- Improve performance
- Make entire middleware stack async capable

This change addresses the need by:

- Refactoring the KeycloakMiddleware to use the MiddlwareMixin

Closes #22 