### PR TITLE
(v2.0.1) - Minor Bug Fixes and settings documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,7 @@ try to login.
 ## Notes
 
 Support for celery 5: from version 0.7.4 on we should use celery 5 for the user sync. This implies running celery with `celery -A app worker ...` instead of `celery worker -A app ...`
+
+## Contact
+
+django-keycloak-auth [at] googlegroups [dot] com

--- a/README.md
+++ b/README.md
@@ -32,15 +32,35 @@ This package should only be used in projects starting from scratch, since it ove
 
     ```python
     KEYCLOAK_CONFIG = {
+        # The Keycloak's Public Server URL (e.g. http://localhost:8080)
         'SERVER_URL': '<PUBLIC_SERVER_URL>',
-        'INTERNAL_URL': '<INTERNAL_SERVER_URL>', # Optional: Default is SERVER_URL
-        'BASE_PATH': '', # Optional: Default matches Keycloak's default '/auth'
+        # The Keycloak's Internal URL 
+        # (e.g. http://keycloak:8080 for a docker service named keycloak)
+        # Optional: Default is SERVER_URL
+        'INTERNAL_URL': '<INTERNAL_SERVER_URL>',
+        # Override for default Keycloak's base path
+        # Default is '/auth/'
+        'BASE_PATH': '/auth/',
+        # The name of the Keycloak's realm
         'REALM': '<REALM_NAME>',
-        'CLIENT_ID': '<CLIENT_ID>',
+        # The ID of this client in the above Keycloak realm
+        'CLIENT_ID': '<CLIENT_ID>' 
+        # The secret for this confidential client
         'CLIENT_SECRET_KEY': '<CLIENT_SECRET_KEY>',
+        # The name of the admin role for the client
         'CLIENT_ADMIN_ROLE': '<CLIENT_ADMIN_ROLE>',
+        # The name of the admin role for the realm
         'REALM_ADMIN_ROLE': '<REALM_ADMIN_ROLE>',
-        'EXEMPT_URIS': [],  # URIS to be ignored by the package
+        # Regex formatted URLs to skip authentication for (uses re.match())
+        'EXEMPT_URIS': [],
+        # Flag if the token should be introspected or decoded (default is False)
+        'DECODE_TOKEN': False,
+        # Flag if the audience in the token should be verified (default is True)
+        'VERIFY_AUDIENCE': True,
+        # Flag if the user info has been included in the token (default is True)
+        'USER_INFO_IN_TOKEN': True,
+        # Flag to show the traceback of debug logs (default is False)
+        'TRACE_DEBUG_LOGS': False
     }
     ```
 
@@ -54,19 +74,10 @@ This package should only be used in projects starting from scratch, since it ove
 
     ```python
     REST_FRAMEWORK = {
+        # ... other rest framework settings.
         'DEFAULT_AUTHENTICATION_CLASSES': [
             'django_keycloak.authentication.KeycloakAuthentication'
         ],
-        'DEFAULT_RENDERER_CLASSES': [
-            'rest_framework.renderers.JSONRenderer',
-        ],
-        'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
-        'PAGE_SIZE': 100,  # Default to 20
-        'PAGINATE_BY_PARAM': 'page_size',
-        # Allow client to override, using `?page_size=xxx`.
-        'MAX_PAGINATE_BY': 100,
-        # Maximum limit allowed when using `?page_size=xxx`.
-        'TEST_REQUEST_DEFAULT_FORMAT': 'json'
     }
     ```
 
@@ -124,8 +135,4 @@ try to login.
 
 ## Notes
 
-Support for celery 5: from version 0.7.4 on we should use celery 5 for the user sync. This implies running celery with celery -A app worker ... instead of celery worker -A app ...
-
-## Contact
-
-django-keycloak-auth [at] googlegroups [dot] com
+Support for celery 5: from version 0.7.4 on we should use celery 5 for the user sync. This implies running celery with `celery -A app worker ...` instead of `celery worker -A app ...`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "django_uw_keycloak"
-version = "2.0.0"
+version = "2.0.1"
 description = "Middleware to allow authorization using Keycloak and Django"
 authors = [
   "Ubiwhere <urbanplatform@ubiwhere.com>",

--- a/src/django_keycloak/backends.py
+++ b/src/django_keycloak/backends.py
@@ -62,10 +62,7 @@ class KeycloakAuthenticationBackend(RemoteUserBackend):
             # `create_from_token` takes cares of password hashing
             user = User.objects.create_from_token(token)
 
-        if token.is_superuser:
-            user.is_staff = user.is_superuser = True
-        else:
-            user.is_staff = user.is_superuser = False
+        user.is_staff = user.is_superuser = bool(token.is_superuser)
 
         user.save()
         return user

--- a/src/django_keycloak/backends.py
+++ b/src/django_keycloak/backends.py
@@ -2,13 +2,13 @@
 Module containing custom Django authentication backends.
 """
 from typing import Optional, Union
-from django.contrib.auth.backends import RemoteUserBackend
+from django.contrib.auth.backends import BaseBackend
 from django.contrib.auth import get_user_model
 from django_keycloak.models import KeycloakUserAutoId, KeycloakUser
 from django_keycloak import Token
 
 
-class KeycloakAuthenticationBackend(RemoteUserBackend):
+class KeycloakAuthenticationBackend(BaseBackend):
     """
     Custom remote backend for Keycloak
     """
@@ -16,7 +16,7 @@ class KeycloakAuthenticationBackend(RemoteUserBackend):
     def authenticate(
         self,
         request,
-        remote_user: Optional[str] = None,
+        username: Optional[str] = None,
         password: Optional[str] = None,
     ):
         """
@@ -26,7 +26,7 @@ class KeycloakAuthenticationBackend(RemoteUserBackend):
 
         Parameters
         ----------
-        remote_user: str
+        username: str
             The Keycloak's username.
         password: str
             The Keycloak's password.
@@ -34,7 +34,7 @@ class KeycloakAuthenticationBackend(RemoteUserBackend):
 
         # Create token from the provided credentials and check if
         # credentials were valid
-        token = Token.from_credentials(remote_user, password)  # type: ignore
+        token = Token.from_credentials(username, password)  # type: ignore
 
         # Check for non-existing or inactive token
         if not token:
@@ -46,7 +46,7 @@ class KeycloakAuthenticationBackend(RemoteUserBackend):
 
         # try to get user from database
         try:
-            user = User.objects.get(username=remote_user)
+            user = User.objects.get(username=username)
             if isinstance(user, KeycloakUserAutoId):
                 # Get user information from token
                 user_info = token.user_info

--- a/src/django_keycloak/config.py
+++ b/src/django_keycloak/config.py
@@ -46,7 +46,7 @@ class Settings:
     def __post_init__(self) -> None:
         # Decide URL (internal url overrides serverl url)
         URL = self.INTERNAL_URL if self.INTERNAL_URL else self.SERVER_URL
-        self.KEYCLOAK_URL = f"{URL}{self.BASE_PATH}"
+        self.KEYCLOAK_URL = f"{URL}/{self.BASE_PATH}/"
 
 
 # Get keycloak configs from django

--- a/src/django_keycloak/config.py
+++ b/src/django_keycloak/config.py
@@ -43,10 +43,39 @@ class Settings:
     # Derived setting of the SERVER/INTERNAL_URL and BASE_PATH
     KEYCLOAK_URL: str = field(init=False)
 
+    def __force_starting_and_ending_slash(self, string: str) -> str:
+        """
+        Forces a given string to start and end with a slash "/"
+
+        Parameters
+        ----------
+        string: str
+            A string to force the starting and ending slash.
+
+        Returns
+        -------
+        str
+            The transformed string starting and ending with a slash.
+        """
+        if not string.endswith("/"):
+            string += "/"
+        if not string.startswith("/"):
+            string = "/" + string
+        return string
+
     def __post_init__(self) -> None:
-        # Decide URL (internal url overrides serverl url)
+
+        # Make sure "BASE_PATH" starts and ends with a slash
+        self.BASE_PATH = self.__force_starting_and_ending_slash(self.BASE_PATH)
+        # Make sure both "SERVER_URL" and "INTERNAL_URL" don't contain any
+        # trailing slash
+        self.SERVER_URL = self.SERVER_URL.rstrip("/")
+        self.INTERNAL_URL = self.INTERNAL_URL.rstrip("/")
+
+        # Decide URL (internal url overrides server url)
         URL = self.INTERNAL_URL if self.INTERNAL_URL else self.SERVER_URL
-        self.KEYCLOAK_URL = f"{URL}/{self.BASE_PATH}/"
+
+        self.KEYCLOAK_URL = f"{URL}{self.BASE_PATH}"
 
 
 # Get keycloak configs from django

--- a/src/django_keycloak/middleware.py
+++ b/src/django_keycloak/middleware.py
@@ -27,6 +27,9 @@ class KeycloakMiddleware(MiddlewareMixin):
         If the authorization is "Basic" (username+password) it tries
         to authenticate the user
         """
+        if "HTTP_AUTHORIZATION" not in request.META:
+            return None
+
         auth_type, value, *_ = request.META.get("HTTP_AUTHORIZATION").split()
 
         if auth_type == "Basic":

--- a/src/django_keycloak/token.py
+++ b/src/django_keycloak/token.py
@@ -217,7 +217,10 @@ class Token:
         # and post error (account not completed.)
         except (KeycloakAuthenticationError, KeycloakPostError) as err:
             logger.debug(
-                f"{type(err).__name__}: {err.args}", exc_info=settings.TRACE_DEBUG_LOGS
+                "%s: %s",
+                type(err).__name__,
+                err.args,
+                exc_info=settings.TRACE_DEBUG_LOGS,
             )
             return None
 


### PR DESCRIPTION
There were some minor bugs in v2:

- The authentication backend was not being reached. Changed to `BaseBackend` and parameter name changed fixed this.
- Forced the ending `/` on `BASE_PATH`, because authentication would fail if user forgot it. Now it is always appended at the end. If user already inserted the URL is built with `//` which is fine for requests.
- Added better header validation in middleware.
- Added better documentation on existing and new settings
- Refactored a log call to use lazy string formatting