### PR TITLE
Fix middleware unbound variable bug & New option for token prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ This package should only be used in projects starting from scratch, since it ove
         # Flag if the user info has been included in the token (default is True)
         'USER_INFO_IN_TOKEN': True,
         # Flag to show the traceback of debug logs (default is False)
-        'TRACE_DEBUG_LOGS': False
+        'TRACE_DEBUG_LOGS': False,
+        # The token prefix that is expected in Authorization header (default is 'Bearer')
+        'TOKEN_PREFIX': 'Bearer'
     }
     ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "django_uw_keycloak"
-version = "2.0.1"
+version = "2.0.2"
 description = "Middleware to allow authorization using Keycloak and Django"
 authors = [
   "Ubiwhere <urbanplatform@ubiwhere.com>",

--- a/src/django_keycloak/admin.py
+++ b/src/django_keycloak/admin.py
@@ -1,6 +1,7 @@
 """
 Module to register models into Django admin dashboard.
 """
+import logging
 from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.utils.html import format_html
@@ -60,4 +61,7 @@ class UserAdmin(admin.ModelAdmin):
         return False
 
 
-admin.site.register(User, UserAdmin)
+try:
+    admin.site.register(User, UserAdmin)
+except admin.sites.AlreadyRegistered:
+    logging.warning(f"Could not register Keycloak UserAdmin")

--- a/src/django_keycloak/admin.py
+++ b/src/django_keycloak/admin.py
@@ -11,6 +11,8 @@ from django_keycloak.config import settings
 
 User = get_user_model()
 
+logger = logging.getLogger(__name__)
+
 
 class UserAdmin(admin.ModelAdmin):
     list_display = (
@@ -64,4 +66,4 @@ class UserAdmin(admin.ModelAdmin):
 try:
     admin.site.register(User, UserAdmin)
 except admin.sites.AlreadyRegistered:
-    logging.warning(f"Could not register Keycloak UserAdmin")
+    logger.warning(f"Could not register Keycloak UserAdmin")

--- a/src/django_keycloak/authentication.py
+++ b/src/django_keycloak/authentication.py
@@ -6,6 +6,7 @@ from django.contrib.auth import get_user_model
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.exceptions import AuthenticationFailed
 from django_keycloak import Token
+from django_keycloak.config import settings
 
 
 class KeycloakAuthentication(TokenAuthentication):
@@ -13,16 +14,14 @@ class KeycloakAuthentication(TokenAuthentication):
     A custom token authentication class for Keycloak.
     """
 
-    # `keyword` refeers to expected prefix in HTTP
-    # Authentication header. We use `Bearer` because it
-    # is commonly used in authorization protocols, such
-    # as OAuth2
-    keyword = "Bearer"
+    # `keyword` refers to expected prefix in HTTP
+    # Authentication header. Use the user-defined prefix
+    keyword = settings.TOKEN_PREFIX
 
     def authenticate_credentials(self, access_token: str):
         """
         Overrides `authenticate_credentials` to provide custom
-        Keycloak authentication for a given Bearer token in a request.
+        Keycloak authentication for a given token in a request.
         """
         # Try to build a Token instance from the provided access token in request
         token: Union[Token, None] = Token.from_access_token(access_token)

--- a/src/django_keycloak/config.py
+++ b/src/django_keycloak/config.py
@@ -39,7 +39,8 @@ class Settings:
     USER_INFO_IN_TOKEN: Optional[bool] = True
     # Flag to show the traceback of debug logs
     TRACE_DEBUG_LOGS: Optional[bool] = False
-
+    # The token prefix
+    TOKEN_PREFIX: Optional[str] = "Bearer"
     # Derived setting of the SERVER/INTERNAL_URL and BASE_PATH
     KEYCLOAK_URL: str = field(init=False)
 

--- a/src/django_keycloak/errors.py
+++ b/src/django_keycloak/errors.py
@@ -4,6 +4,14 @@ Module containing custom errors.
 import django_keycloak.config as config
 
 
+class KeycloakError(Exception):
+    """
+    Base exception for the library
+    """
+
+    pass
+
+
 class KeycloakAPIError(Exception):
     """
     This should be raised on KeycloakAPIErrors

--- a/src/django_keycloak/errors.py
+++ b/src/django_keycloak/errors.py
@@ -4,14 +4,6 @@ Module containing custom errors.
 import django_keycloak.config as config
 
 
-class KeycloakError(Exception):
-    """
-    Base exception for the library
-    """
-
-    pass
-
-
 class KeycloakAPIError(Exception):
     """
     This should be raised on KeycloakAPIErrors

--- a/src/django_keycloak/middleware.py
+++ b/src/django_keycloak/middleware.py
@@ -13,7 +13,6 @@ from django_keycloak import Token
 from django_keycloak.config import settings
 from django_keycloak.models import KeycloakUser, KeycloakUserAutoId
 from django_keycloak.config import settings
-from django_keycloak.errors import KeycloakError
 
 AUTH_HEADER = "HTTP_AUTHORIZATION"
 


### PR DESCRIPTION
Currently, the middleware has a bug when checking for authentication type.
If user tries to use an authentication different from `basic` or `Bearer` (e.g. `JWT`) we have an unbound variable `token` error. This PR fixes this issue by creating a new config variable for the user to specify the token prefix that should be expected (still defaults to `Bearer`), but adds more flexibility. If the auth type is not basic or the user-specified token prefix a `None` value is returned, fixing the unbound variable error.

Also, a small fix in the admin was made. When registering our model into model admin, I've added a try catch, in case the `AUTH_USER_MODEL` has already been registered (the user can have multiple auth systems all trying to register an auth user admin).