### PR TITLE
Modified the username field length

### DIFF
--- a/src/django_keycloak/models.py
+++ b/src/django_keycloak/models.py
@@ -18,7 +18,7 @@ class AbstractKeycloakUser(AbstractBaseUser, PermissionsMixin):
         self._cached_user_info = None
 
     id = models.UUIDField(_("keycloak_id"), unique=True, primary_key=True)
-    username = models.CharField(_("username"), unique=True, max_length=20)
+    username = models.CharField(_("username"), unique=True, max_length=32)
     is_staff = models.BooleanField(default=False)
     is_superuser = models.BooleanField(default=False)
     is_active = models.BooleanField(default=True)


### PR DESCRIPTION
Increased the length of the username field in the user model as 20 is a bit low, I can't even use UUID or email for the username field as it break it.