### PR TITLE
Automatically refresh Keycloak token

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ This package should only be used in projects starting from scratch, since it ove
         'TRACE_DEBUG_LOGS': False,
         # The token prefix that is expected in Authorization header (default is 'Bearer')
         'TOKEN_PREFIX': 'Bearer'
+        # For the KeycloakAdmin, which HTTP methods to refresh the token for
+        # Only used in Python-Keycloak < v3
+        'AUTO_REFRESH_TOKEN': ["get", "put", "post", "delete"]
     }
     ```
 

--- a/src/django_keycloak/admin.py
+++ b/src/django_keycloak/admin.py
@@ -66,4 +66,4 @@ class UserAdmin(admin.ModelAdmin):
 try:
     admin.site.register(User, UserAdmin)
 except admin.sites.AlreadyRegistered:
-    logger.warning(f"Could not register Keycloak UserAdmin")
+    logger.warning("Could not register Keycloak UserAdmin")

--- a/src/django_keycloak/api/views.py
+++ b/src/django_keycloak/api/views.py
@@ -1,15 +1,13 @@
 from django.contrib.auth import get_user_model
-from rest_framework import mixins, permissions
-from rest_framework import status
-from rest_framework import viewsets, generics
+from rest_framework import generics, mixins, permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from django_keycloak.api.filters import DRYPermissionFilter
 from django_keycloak.api.serializers import (
     GetTokenSerializer,
-    RefreshTokenSerializer,
     KeycloakUserAutoIdSerializer,
+    RefreshTokenSerializer,
 )
 
 

--- a/src/django_keycloak/config.py
+++ b/src/django_keycloak/config.py
@@ -41,6 +41,8 @@ class Settings:
     TRACE_DEBUG_LOGS: Optional[bool] = False
     # The token prefix
     TOKEN_PREFIX: Optional[str] = "Bearer"
+    # For the KeycloakAdmin, which HTTP methods to refresh the token for
+    AUTO_REFRESH_TOKEN: Optional[List[str]] = None
     # Derived setting of the SERVER/INTERNAL_URL and BASE_PATH
     KEYCLOAK_URL: str = field(init=False)
 

--- a/src/django_keycloak/connector.py
+++ b/src/django_keycloak/connector.py
@@ -70,10 +70,16 @@ class LazyKeycloakAdmin(KeycloakAdmin):
                 raise error
 
 
+options = {
+    "server_url": settings.KEYCLOAK_URL,
+    "client_id": settings.CLIENT_ID,
+    "realm_name": settings.REALM,
+    "client_secret_key": settings.CLIENT_SECRET_KEY,
+}
+# auto_refresh_token will be removed and be on by default in python-keycloak v3
+# Therefore, make it optional to avoid breaking compatibility
+if settings.AUTO_REFRESH_TOKEN:
+    options["auto_refresh_token"] = settings.AUTO_REFRESH_TOKEN
+
 # The exported module variable
-lazy_keycloak_admin = LazyKeycloakAdmin(
-    server_url=settings.KEYCLOAK_URL,
-    client_id=settings.CLIENT_ID,
-    realm_name=settings.REALM,
-    client_secret_key=settings.CLIENT_SECRET_KEY,
-)
+lazy_keycloak_admin = LazyKeycloakAdmin(**options)

--- a/src/django_keycloak/middleware.py
+++ b/src/django_keycloak/middleware.py
@@ -12,7 +12,6 @@ from django.utils.deprecation import MiddlewareMixin
 from django_keycloak import Token
 from django_keycloak.config import settings
 from django_keycloak.models import KeycloakUser, KeycloakUserAutoId
-from django_keycloak.config import settings
 
 AUTH_HEADER = "HTTP_AUTHORIZATION"
 


### PR DESCRIPTION
Why:

- Reduce auth calls and avoid auth failures

This change addresses the need by:

- Enabling auto refresh token in python-keycloak < v3
- Cleaning up imports